### PR TITLE
Conda build

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py --sse2 --sse3 install
+if errorlevel 1 exit 1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py --sse2 --sse3 install     # Python command to install the script.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.1.0"
 
 source:
-  git_rev: 14360ce2248f69ef8bdeead5346b250d4427a417
+  git_rev: 38a37168bccea7b218dfd2540ce32c4ec58ec4d0
   git_url: https://github.com/naspert/plotpy.git
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: plotpy
+  version: "0.1.0"
+
+source:
+  git_rev: 14360ce2248f69ef8bdeead5346b250d4427a417
+  git_url: https://github.com/naspert/plotpy.git
+
+requirements:
+  build:
+    - python
+    - sip
+    - qt
+    - spyder
+    - h5py
+    - cython
+    - pillow
+    - scipy
+    - numpy
+  run:
+    - python
+
+test:
+  imports:
+    - plotpy
+
+about:
+  home: https://github.com/PierreRaybaut/plotpy
+  license: CeciLL
+  license_file: Licence_CeCILL_V2-en.txt

--- a/plotpy/transitional.py
+++ b/plotpy/transitional.py
@@ -16,7 +16,7 @@ No other ``plotpy`` module should import ``qwt`` or use any of its
 interfaces directly.
 """
 
-from qwt import (QwtPlot, QwtSymbol, QwtLinearScaleEngine, QwtLogScaleEngine,
+from plotpy.qwt import (QwtPlot, QwtSymbol, QwtLinearScaleEngine, QwtLogScaleEngine,
                  QwtText, QwtPlotCanvas, QwtLinearColorMap, QwtInterval,
                  toQImage, QwtPlotGrid, QwtPlotItem, QwtScaleMap, QwtPlotCurve,
                  QwtPlotMarker, QwtPlotRenderer)

--- a/setup.py
+++ b/setup.py
@@ -79,11 +79,10 @@ Building, installation, ...
 ---------------------------
 
 The following packages are **required**: `PyQt4`_ (or `PyQt5`_), 
-`PythonQwt`_, `plotpy`_, `NumPy`_, `SciPy`_ and `Pillow`_.
+`plotpy`_, `NumPy`_, `SciPy`_ and `Pillow`_.
 
 .. _PyQt4: https://pypi.python.org/pypi/PyQt4
 .. _PyQt5: https://pypi.python.org/pypi/PyQt5
-.. _PythonQwt: https://pypi.python.org/pypi/PythonQwt
 .. _plotpy: https://pypi.python.org/pypi/plotpy
 .. _NumPy: https://pypi.python.org/pypi/NumPy
 .. _SciPy: https://pypi.python.org/pypi/SciPy
@@ -198,8 +197,8 @@ setup(name=LIBNAME, version=__version__,
                     get_package_data(LIBNAME, ('.png', '.svg', '.mo', '.dcm',
                                                '.ui'))},
       data_files=[(r'Doc', [CHM_DOC])] if CHM_DOC else [],
-      install_requires=["NumPy>=1.3", "SciPy>=0.7", "plotpy>=1.7.0",
-                        "PythonQwt>=0.5.0", "Pillow"],
+      install_requires=["NumPy>=1.3", "SciPy>=0.7",
+                        "Pillow"],
       extras_require = {
                         'Doc':  ["Sphinx>=1.1"],
                         'DICOM':  ["pydicom>=0.9.3"],


### PR DESCRIPTION
these changes (I took one from a pull request #7 ) allow plotpy to build and be installed via anaconda (only tested on windows 64).
Resulting packages (for python 3.5 and 3.6) are available here https://anaconda.org/naspert/plotpy