### PR TITLE
fixing unicode issue: #10

### DIFF
--- a/plotpy/userconfig.py
+++ b/plotpy/userconfig.py
@@ -50,6 +50,9 @@ import sys
 from plotpy.py3compat import configparser as cp
 from plotpy.py3compat import is_text_string, is_unicode, PY2
 
+if not PY2:
+    unicode = str
+
 def _check_values(sections):
     # Checks if all key/value pairs are writable
     err = False


### PR DESCRIPTION
Hi,

In response about #10 I propose a simple solution: 
a revival of unicode for Python 3  by simply aliasing `str` as `unicode` using PY2 varialbe from py3compat module.

Doing so, I believe python2  would still work and python 3 will work (I made it my self twice this day !).

Cheers,

Jérémie.